### PR TITLE
Hoge

### DIFF
--- a/src/rest/cosmos/base/tendermint/module.ts
+++ b/src/rest/cosmos/base/tendermint/module.ts
@@ -24,6 +24,23 @@ export async function getLatestValidatorSet(
   );
 }
 
+export async function getValidatorSet(
+  sdk: CosmosSDK,
+  height: bigint,
+  paginationKey?: string,
+  paginationOffset?: bigint,
+  paginationLimit?: bigint,
+  paginationCountTotal?: boolean,
+) {
+  return new ServiceApi(undefined, sdk.url).getValidatorSetByHeight(
+    height.toString(),
+    paginationKey,
+    paginationOffset?.toString(),
+    paginationLimit?.toString(),
+    paginationCountTotal,
+  );
+}
+
 export function getNodeInfo(sdk: CosmosSDK) {
   return new ServiceApi(undefined, sdk.url).getNodeInfo();
 }

--- a/src/rest/cosmos/base/tendermint/module.ts
+++ b/src/rest/cosmos/base/tendermint/module.ts
@@ -24,7 +24,7 @@ export async function getLatestValidatorSet(
   );
 }
 
-export async function getValidatorSet(
+export async function getValidatorSetByHeight(
   sdk: CosmosSDK,
   height: bigint,
   paginationKey?: string,


### PR DESCRIPTION
TendermintのFunctionにgetValidatorSetByHeight を追加
ブロック高指定でValidatorsetを取得できるように