### PR TITLE
feat: add time utils to codec

### DIFF
--- a/src/types/codec/codec.spec.ts
+++ b/src/types/codec/codec.spec.ts
@@ -1,4 +1,7 @@
 import { proto, cosmosclient } from '../..';
+import { google } from '../../proto';
+import { goTimeStringToJsDate, jsDateToGoTimeString, jsDateToProtobufTimestamp, protobufTimestampToJsDate } from './module';
+import Long from 'long';
 
 describe('codec', () => {
   it('cosmosJSONStringify', async () => {
@@ -12,7 +15,7 @@ describe('codec', () => {
     const pubKey = privKey.pubKey();
     const address = cosmosclient.AccAddress.fromPublicKey(pubKey);
 
-    expect(address.toString()).toStrictEqual('cosmos14ynfqqa6j5k3kcqm2ymf3l66d9x07ysxgnvdyx');
+    expect(address.toString()).toBe('cosmos14ynfqqa6j5k3kcqm2ymf3l66d9x07ysxgnvdyx');
 
     const fromAddress = address;
     const toAddress = address;
@@ -119,5 +122,44 @@ describe('codec', () => {
     console.log(key);
 
     expect(true).toBeTruthy();
+  });
+
+  it('goTimeStringToJsDate', () => {
+    expect.hasAssertions();
+    const originalGoTimeString = '2021-12-09T18:00:00+09:00';
+    const resultJsDate = goTimeStringToJsDate(originalGoTimeString);
+    const resultJsDateTimestamp = resultJsDate.toUTCString();
+    const expectedDateTimestamp = new Date(2021, 11, 9, 18, 0, 0).toUTCString();
+    expect(resultJsDateTimestamp).toBe(expectedDateTimestamp);
+  });
+
+  it('jsDateToGoTimeString', () => {
+    expect.hasAssertions();
+    const originalDate = new Date(2021, 11, 9, 18, 0, 0);
+    const resultDateString = jsDateToGoTimeString(originalDate);
+    expect(resultDateString).toBe('2021-12-09T18:00:00+09:00');
+  });
+
+  it('jsDateToProtobufTimestamp', () => {
+    expect.hasAssertions();
+    const originalDate = new Date(2021, 11, 9, 18, 0, 0);
+    const protobufTimestamp = jsDateToProtobufTimestamp(originalDate);
+    expect(protobufTimestamp.seconds.low).toBe(1639040400);
+    expect(protobufTimestamp.seconds.high).toBe(0);
+    expect(protobufTimestamp.seconds.unsigned).toBe(false);
+  });
+
+  it('protobufTimestampToJsDate', () => {
+    expect.hasAssertions();
+    const protobufTimestamp = new google.protobuf.Timestamp({
+      seconds: Long.fromNumber(new Date(2021, 11, 9, 18, 0, 0).getTime() / 1000),
+    });
+    const date = protobufTimestampToJsDate(protobufTimestamp);
+    expect(date.getFullYear()).toBe(2021);
+    expect(date.getMonth()).toBe(11);
+    expect(date.getDate()).toBe(9);
+    expect(date.getHours()).toBe(18);
+    expect(date.getMinutes()).toBe(0);
+    expect(date.getSeconds()).toBe(0);
   });
 });

--- a/src/types/codec/module.ts
+++ b/src/types/codec/module.ts
@@ -49,6 +49,9 @@ export function packCosmosAny(value: any): Object {
   if (value instanceof google.protobuf.Any) {
     return packCosmosAny(unpackAny(value));
   }
+  if (value instanceof google.protobuf.Timestamp) {
+    return jsDateToGoTimeString(protobufTimestampToJsDate(value));
+  }
   if (value instanceof Long) {
     return value.toString();
   }
@@ -138,4 +141,42 @@ export function packAny(value: any) {
   });
 
   return packed;
+}
+
+export function goTimeStringToJsDate(goTimeString: string): Date {
+  return new Date(Date.parse(goTimeString));
+}
+
+export function jsDateToGoTimeString(jsDate: Date): string {
+  const timezoneOffset = jsDate.getTimezoneOffset();
+  const timezoneHours = timezoneOffset / 60;
+  const timezoneMinutes = timezoneOffset % 60;
+  const rfc3339 = [
+    jsDate.getFullYear(),
+    '-',
+    `0${jsDate.getMonth() + 1}`.slice(-2),
+    '-',
+    `0${jsDate.getDate()}`.slice(-2),
+    'T',
+    `0${jsDate.getHours()}`.slice(-2),
+    ':',
+    `0${jsDate.getMinutes()}`.slice(-2),
+    ':',
+    `0${jsDate.getSeconds()}`.slice(-2),
+    -timezoneHours < 0 ? '' : '+',
+    `0${-timezoneHours}`.slice(-2),
+    ':',
+    `0${timezoneMinutes}`.slice(-2),
+  ].join('');
+  return rfc3339;
+}
+
+export function jsDateToProtobufTimestamp(jsDate: Date): google.protobuf.Timestamp {
+  return new google.protobuf.Timestamp({
+    seconds: Long.fromNumber(jsDate.getTime() / 1000),
+  });
+}
+
+export function protobufTimestampToJsDate(protobufTimestamp: google.protobuf.Timestamp): Date {
+  return new Date(protobufTimestamp.seconds.toNumber() * 1000);
 }


### PR DESCRIPTION
Add conversion methods of following data types.

- js Date
- google.protobuf.Timestamp
- go time string format