### PR TITLE
feat: json-sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ describe('bank', () => {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
+      .then((res) => res.data.account && cosmosclient.codec.protoJSONToInstance(res.data.account))
       .catch((_) => undefined);
 
     if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
@@ -64,12 +64,12 @@ describe('bank', () => {
     });
 
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({
-      messages: [cosmosclient.codec.packAny(msgSend)],
+      messages: [cosmosclient.codec.instanceToProtoAny(msgSend)],
     });
     const authInfo = new proto.cosmos.tx.v1beta1.AuthInfo({
       signer_infos: [
         {
-          public_key: cosmosclient.codec.packAny(pubKey),
+          public_key: cosmosclient.codec.instanceToProtoAny(pubKey),
           mode_info: {
             single: {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmos-client/core",
-  "version": "0.45.4",
+  "version": "0.45.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmos-client/core",
-      "version": "0.45.4",
+      "version": "0.45.5",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cosmos-client/core",
   "description": "REST API client for Cosmos SDK blockchain",
-  "version": "0.45.4",
+  "version": "0.45.5",
   "author": "CauchyE, Inc.",
   "bugs": {
     "url": "https://github.com/cosmos-client/cosmos-client-ts/issues"

--- a/src/rest/bank/bank.spec.ts
+++ b/src/rest/bank/bank.spec.ts
@@ -20,7 +20,7 @@ describe('bank', () => {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then((res) => res.data.account && cosmosclient.codec.protoJSONToInstance(res.data.account))
+      .then((res) => res.data.account && cosmosclient.codec.protoJSONToInstance(res.data.account as { '@type': string }))
       .catch(() => undefined);
 
     if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {

--- a/src/rest/bank/bank.spec.ts
+++ b/src/rest/bank/bank.spec.ts
@@ -20,7 +20,7 @@ describe('bank', () => {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
+      .then((res) => res.data.account && cosmosclient.codec.protoJSONToInstance(res.data.account))
       .catch(() => undefined);
 
     if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
@@ -36,12 +36,12 @@ describe('bank', () => {
     });
 
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({
-      messages: [cosmosclient.codec.packAny(msgSend)],
+      messages: [cosmosclient.codec.instanceToProtoAny(msgSend)],
     });
     const authInfo = new proto.cosmos.tx.v1beta1.AuthInfo({
       signer_infos: [
         {
-          public_key: cosmosclient.codec.packAny(pubKey),
+          public_key: cosmosclient.codec.instanceToProtoAny(pubKey),
           mode_info: {
             single: {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,

--- a/src/rest/tx/index.ts
+++ b/src/rest/tx/index.ts
@@ -11,3 +11,9 @@ codec.register('/cosmos.tx.v1beta1.SignerInfo', cosmos.tx.v1beta1.SignerInfo);
 codec.register('/cosmos.tx.v1beta1.Tx', cosmos.tx.v1beta1.Tx);
 codec.register('/cosmos.tx.v1beta1.TxBody', cosmos.tx.v1beta1.TxBody);
 codec.register('/cosmos.tx.v1beta1.TxRaw', cosmos.tx.v1beta1.TxRaw);
+codec.registerConvertJSON(cosmos.tx.v1beta1.ModeInfo, (value) => {
+  if (value?.single) {
+    value.single.mode = cosmos.tx.signing.v1beta1.SignMode[value.single.mode];
+  }
+  return value;
+});

--- a/src/rest/tx/index.ts
+++ b/src/rest/tx/index.ts
@@ -1,1 +1,13 @@
+import { cosmos } from '../../proto';
+import { codec } from '../../types';
+
 export * as tx from './module';
+
+codec.register('/cosmos.tx.v1beta1.AuthInfo', cosmos.tx.v1beta1.AuthInfo);
+codec.register('/cosmos.tx.v1beta1.Fee', cosmos.tx.v1beta1.Fee);
+codec.register('/cosmos.tx.v1beta1.ModeInfo', cosmos.tx.v1beta1.ModeInfo);
+codec.register('/cosmos.tx.v1beta1.SignDoc', cosmos.tx.v1beta1.SignDoc);
+codec.register('/cosmos.tx.v1beta1.SignerInfo', cosmos.tx.v1beta1.SignerInfo);
+codec.register('/cosmos.tx.v1beta1.Tx', cosmos.tx.v1beta1.Tx);
+codec.register('/cosmos.tx.v1beta1.TxBody', cosmos.tx.v1beta1.TxBody);
+codec.register('/cosmos.tx.v1beta1.TxRaw', cosmos.tx.v1beta1.TxRaw);

--- a/src/types/codec/codec.spec.ts
+++ b/src/types/codec/codec.spec.ts
@@ -4,7 +4,7 @@ import { goTimeStringToJsDate, jsDateToGoTimeString, jsDateToProtobufTimestamp, 
 import Long from 'long';
 
 describe('codec', () => {
-  it('cosmosJSONStringify', async () => {
+  it('txBuilder', async () => {
     expect.hasAssertions();
 
     const sdk = new cosmosclient.CosmosSDK('http://localhost:1317', 'testchain');
@@ -28,12 +28,12 @@ describe('codec', () => {
     });
 
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({
-      messages: [cosmosclient.codec.packAny(msgSend)],
+      messages: [cosmosclient.codec.instanceToProtoAny(msgSend)],
     });
     const authInfo = new proto.cosmos.tx.v1beta1.AuthInfo({
       signer_infos: [
         {
-          public_key: cosmosclient.codec.packAny(pubKey),
+          public_key: cosmosclient.codec.instanceToProtoAny(pubKey),
           mode_info: {
             single: {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
@@ -53,11 +53,34 @@ describe('codec', () => {
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     // broadcast
-    const json = txBuilder.cosmosJSONStringify(2);
+    const json = txBuilder.protoJSONStringify(2);
     console.log(json);
+
+    expect(true).toBeTruthy();
   });
 
-  it('unpackAny', () => {
+  it('protoJSONStringify', () => {
+    expect.hasAssertions();
+
+    const account = {
+      '@type': '/cosmos.auth.v1beta1.BaseAccount',
+      address: 'jpyx10lcj22kzftvnduchatmnsnhfljeky5ghd398wt',
+      account_number: '0',
+      pub_key: { '@type': '/cosmos.crypto.secp256k1.PubKey', key: 'AvSf2U/B23UZKvLTD0E4xqJ33Nn0Z552nXCkkwEfleiu' },
+      sequence: '13',
+    };
+
+    const unpacked = cosmosclient.codec.protoJSONToInstance(account);
+    if (!(unpacked instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
+      throw Error('');
+    }
+    const json = cosmosclient.codec.instanceToProtoJSON(unpacked);
+    console.log(json);
+
+    expect(true).toBeTruthy();
+  });
+
+  it('protoJSONToInstance', () => {
     expect.hasAssertions();
     const res = {
       data: {
@@ -111,14 +134,14 @@ describe('codec', () => {
       },
     };
 
-    const unpacked = cosmosclient.codec.unpackCosmosAny(res.data.account);
+    const unpacked = cosmosclient.codec.protoJSONToInstance(res.data.account);
     if (!(unpacked instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
       throw Error('');
     }
 
     console.log(unpacked);
 
-    const key = cosmosclient.codec.unpackAny(unpacked.pub_key);
+    const key = cosmosclient.codec.protoAnyToInstance(unpacked.pub_key);
     console.log(key);
 
     expect(true).toBeTruthy();

--- a/src/types/codec/config.ts
+++ b/src/types/codec/config.ts
@@ -2,5 +2,6 @@ import { protoMessage } from './module';
 
 export const codecMaps = {
   constructor: {} as { [type: string]: protoMessage },
-  inv: new Map<Function, string>(),
+  inv: new Map<protoMessage, string>(),
+  convertJSON: new Map<protoMessage, (value: any) => any>(),
 };

--- a/src/types/codec/config.ts
+++ b/src/types/codec/config.ts
@@ -1,8 +1,6 @@
-import * as $protobuf from 'protobufjs';
+import { protoMessage } from './module';
 
 export const codecMaps = {
+  constructor: {} as { [type: string]: protoMessage },
   inv: new Map<Function, string>(),
-  encode: {} as { [type: string]: (value: any) => $protobuf.Writer },
-  decode: {} as { [type: string]: (value: Uint8Array) => unknown },
-  fromObject: {} as { [type: string]: (value: any) => unknown },
 };

--- a/src/types/crypto/ed25519.spec.ts
+++ b/src/types/crypto/ed25519.spec.ts
@@ -14,8 +14,8 @@ describe('ed25519', () => {
       '@type': '/cosmos.crypto.ed25519.PrivKey',
       key: 'vGqFxQ10qeP98qJ/mdpcJpPTkc6uqI0dr9x6L9AFSEMKomyxKj5rctJAcqBtuov8pMt4QJk78lzeWuxBxj/Y+g==',
     };
-    const publicKeyUnpack = cosmosclient.codec.unpackCosmosAny(pub_key) as cosmosclient.PubKey;
-    const privateKeyUnpack = cosmosclient.codec.unpackCosmosAny(priv_key) as cosmosclient.PrivKey;
+    const publicKeyUnpack = cosmosclient.codec.protoJSONToInstance(pub_key) as cosmosclient.PubKey;
+    const privateKeyUnpack = cosmosclient.codec.protoJSONToInstance(priv_key) as cosmosclient.PrivKey;
 
     //check1 (encoded public key from packed pubkey vs packed privkey )
     expect(publicKeyUnpack.accPubkey()).toBe(privateKeyUnpack.pubKey().accPubkey());
@@ -43,8 +43,8 @@ describe('ed25519', () => {
       '@type': '/cosmos.crypto.ed25519.PrivKey',
       key: 'Q7RecOq++QctQfKXqBOnrvMIT81sC8KaIE+HY+ZfsOn6rx1S1h6mlrfJx0oUhzUOX061UttNWVegGmaw47injQ==',
     };
-    const publicKeyUnpack = cosmosclient.codec.unpackCosmosAny(pub_key) as cosmosclient.PubKey;
-    const privateKeyUnpack = cosmosclient.codec.unpackCosmosAny(priv_key) as cosmosclient.PrivKey;
+    const publicKeyUnpack = cosmosclient.codec.protoJSONToInstance(pub_key) as cosmosclient.PubKey;
+    const privateKeyUnpack = cosmosclient.codec.protoJSONToInstance(priv_key) as cosmosclient.PrivKey;
 
     //check1 (encoded public key from packed pubkey vs packed privkey )
     expect(publicKeyUnpack.accPubkey()).toBe(privateKeyUnpack.pubKey().accPubkey());

--- a/src/types/crypto/index.spec.ts
+++ b/src/types/crypto/index.spec.ts
@@ -1,7 +1,7 @@
 import { cosmosclient } from '../..';
 
 describe('sdk', () => {
-  it('sdk', async () => {
+  it('multisig', async () => {
     expect.hasAssertions();
     const json = `
     {

--- a/src/types/crypto/index.spec.ts
+++ b/src/types/crypto/index.spec.ts
@@ -46,7 +46,7 @@ describe('sdk', () => {
     }
 `;
     const obj = JSON.parse(json);
-    const unpacked = cosmosclient.codec.unpackCosmosAny(obj);
+    const unpacked = cosmosclient.codec.protoJSONToInstance(obj);
 
     console.log(unpacked);
 

--- a/src/types/crypto/secp256k1.spec.ts
+++ b/src/types/crypto/secp256k1.spec.ts
@@ -31,20 +31,19 @@ describe('secp256k1', () => {
     expect.hasAssertions();
 
     //packed publickey from gaia CLI
-    const pubKeyCLI =
-    {
-      "@type": "/cosmos.crypto.secp256k1.PubKey",
-      "key": "A8Pj5Q8u3hShw3+oFc4nGrZvKl4avTDHW1m9GiI1fm5x"
-    }
-    const publicKeyCLI = cosmosclient.codec.unpackCosmosAny(pubKeyCLI) as cosmosclient.PubKey;
+    const pubKeyCLI = {
+      '@type': '/cosmos.crypto.secp256k1.PubKey',
+      key: 'A8Pj5Q8u3hShw3+oFc4nGrZvKl4avTDHW1m9GiI1fm5x',
+    };
+    const publicKeyCLI = cosmosclient.codec.protoJSONToInstance(pubKeyCLI) as cosmosclient.PubKey;
 
     //publickey from mnemonic
     const mnemonic =
-      "joy furnace inject spot engine source alpha turn east visa abstract cousin shell express weasel math perfect tiger quality camp mansion desert web jaguar"
+      'joy furnace inject spot engine source alpha turn east visa abstract cousin shell express weasel math perfect tiger quality camp mansion desert web jaguar';
     const privKey = new proto.cosmos.crypto.secp256k1.PrivKey({
       key: await cosmosclient.generatePrivKeyFromMnemonic(mnemonic),
     });
-    const pubkey = privKey.pubKey()
+    const pubkey = privKey.pubKey();
 
     //check (encoded publickey from pack vs mnemonic )
     expect(pubkey.accPubkey()).toBe(publicKeyCLI.accPubkey());

--- a/src/types/tx-builder.ts
+++ b/src/types/tx-builder.ts
@@ -47,40 +47,20 @@ export class TxBuilder {
     return Buffer.from(bytes).toString('base64');
   }
 
-  packCosmosAny() {
+  toProtoJSON() {
     const body = cosmos.tx.v1beta1.TxBody.decode(this.txRaw.body_bytes);
     const authInfo = cosmos.tx.v1beta1.AuthInfo.decode(this.txRaw.auth_info_bytes);
 
-    return codec.packCosmosAny({
-      body,
-      auth_info: authInfo,
-      signatures: this.txRaw.signatures,
-    });
+    return codec.instanceToProtoJSON(
+      new cosmos.tx.v1beta1.Tx({
+        body,
+        auth_info: authInfo,
+        signatures: this.txRaw.signatures,
+      }),
+    );
   }
 
-  cosmosJSONStringify(space?: number) {
-    return JSON.stringify(this.canonicalizeJSON(this.packCosmosAny()), undefined, space);
-  }
-
-  canonicalizeJSON(value: any): any {
-    if (Object.prototype.toString.call(value) === '[object Object]') {
-      const sorted = {} as { [key: string]: any };
-      const keys = Object.keys(value).sort();
-
-      for (const key of keys) {
-        const keyValue = value[key];
-        if (keyValue != null) {
-          sorted[key] = this.canonicalizeJSON(keyValue);
-        }
-      }
-
-      return sorted;
-    }
-
-    if (Array.isArray(value)) {
-      return value.map((element) => this.canonicalizeJSON(element));
-    }
-
-    return value === undefined ? null : value;
+  protoJSONStringify(space?: number) {
+    return JSON.stringify(this.toProtoJSON(), undefined, space);
   }
 }


### PR DESCRIPTION
You can check the work by

```
npx jest codec -t txBuilder
```

I solve this problem by using the keys order of the prototype(javascript term) of the instance. Really techy and depends on the fuckin specification of protobufjs.
In protobufjs, the order of fields are preserved in prototype, but not in the actual instance.