### PR TITLE
feat: added a check when expanding an array

### DIFF
--- a/src/types/codec/codec.spec.ts
+++ b/src/types/codec/codec.spec.ts
@@ -1,4 +1,4 @@
-import { proto, cosmosclient } from '../..';
+import { proto, cosmosclient, rest } from '../..';
 import { google } from '../../proto';
 import { goTimeStringToJsDate, jsDateToGoTimeString, jsDateToProtobufTimestamp, protobufTimestampToJsDate } from './module';
 import Long from 'long';
@@ -185,4 +185,27 @@ describe('codec', () => {
     expect(date.getMinutes()).toBe(0);
     expect(date.getSeconds()).toBe(0);
   });
+
+
+  it('protoJSONToInstanceTxMsg', async () => {
+    expect.hasAssertions();
+
+    const sdk = new cosmosclient.CosmosSDK('https://ununifi-alpha-test-v2.cauchye.net:1318', 'ununifi-alpha-test-v2');
+
+    const hashSend = "AF78448BFBF4725FA9EF8382B52743210B6EBC3B02BE26C2BCB288202F0DE73B" //msgSend 100uguu
+    const txResponce = await rest.tx.getTx(sdk, hashSend).then((res) => res.data)
+    const messase = txResponce.tx?.body?.messages?.[0]
+    const cast = cosmosclient.codec.castProtoJSONOfProtoAny(messase)
+    const instance = cosmosclient.codec.protoJSONToInstance(cast)
+    expect((instance as any).constructor.name).toBe("MsgSend");
+    console.log("cast-msgSend", cast)
+    console.log("instanceMsgSend", instance)
+
+    const hashSubmit = "8B21739E3568727D0C30E469910359643E2B85E88B0B223E644566692721F5D8" //msgSubmitProposal
+    const txResponceS = await rest.tx.getTx(sdk, hashSubmit).then((res) => res.data)
+    const instanceProposal = cosmosclient.codec.protoJSONToInstance(cosmosclient.codec.castProtoJSONOfProtoAny(txResponceS.tx?.body?.messages?.[0]))
+    expect((instanceProposal as any).constructor.name).toBe("MsgSubmitProposal");
+    console.log("insetanceProposal", instanceProposal)
+  });
+
 });

--- a/src/types/codec/module.ts
+++ b/src/types/codec/module.ts
@@ -31,6 +31,10 @@ export function isProtoJSONOfProtoAny(value: unknown): value is ProtoJSONOfProto
   return typeof value === 'object' && value != null && '@type' in value;
 }
 
+export function isProtoJSONOfProtoAnyArray(value: unknown): value is ProtoJSONOfProtoAny[] {
+  return value instanceof Array && value.every((v) => isProtoJSONOfProtoAny(v))
+}
+
 /**
  * Instance -> ProtoJSON
  * @param value
@@ -127,7 +131,7 @@ export function protoJSONToInstance<T>(value: ProtoJSONOfProtoAny | null | undef
   for (const [key, _v] of Object.entries(value)) {
     const v: unknown = _v;
 
-    if (v instanceof Array) {
+    if (isProtoJSONOfProtoAnyArray(v)) {
       const array = protoJSONArrayToInstance(v);
       if (array instanceof Error) {
         return array;


### PR DESCRIPTION
@KimuraYu45z  cc @YasunoriMATSUOKA 

msgSend could not be a instance using ` protoJSONToInstance()`.
Because `protoJSONToInstance()` was trying to make Coin [ ] in msgSend to be instance.
But Coin [ ] does not have @type.

So before instantiating the array, I make sure element has @type.

Please check out the test I added.
Then Please review. 🙏 

```
  console.log
    instanceMsgSend MsgSend {
      amount: [ Coin { denom: 'uguu', amount: '100' } ],  <---- 
      from_address: 'ununifi18y5nnx3r9s4w398sn0nqcykh2y7sx8ljd423t6',
      to_address: 'ununifi13py92x52g66wt980v8lc0wpzv38u7dnz9t7k3s'
    }
```
