### PR TITLE
fix: from v1beta1 to v1 in distribution module and bump @cosmos-client/core to v0.46.0-rc4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmos-client/core",
-  "version": "0.46.0-rc3",
+  "version": "0.46.0-rc4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmos-client/core",
-      "version": "0.46.0-rc3",
+      "version": "0.46.0-rc4",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cosmos-client/core",
   "description": "REST API client for Cosmos SDK blockchain",
-  "version": "0.46.0-rc3",
+  "version": "0.46.0-rc4",
   "author": "CauchyE, Inc.",
   "bugs": {
     "url": "https://github.com/cosmos-client/cosmos-client-ts/issues"

--- a/src/rest/gov/index.ts
+++ b/src/rest/gov/index.ts
@@ -3,8 +3,8 @@ import { codec } from '../../types';
 
 export * as gov from './module';
 
-codec.register('/cosmos.gov.v1beta1.MsgDeposit', cosmos.gov.v1beta1.MsgDeposit);
+codec.register('/cosmos.gov.v1.MsgDeposit', cosmos.gov.v1.MsgDeposit);
 codec.register('/cosmos.gov.v1beta1.MsgSubmitProposal', cosmos.gov.v1beta1.MsgSubmitProposal);
-codec.register('/cosmos.gov.v1beta1.MsgVoteWeighted', cosmos.gov.v1beta1.MsgVoteWeighted);
-codec.register('/cosmos.gov.v1beta1.MsgVote', cosmos.gov.v1beta1.MsgVote);
+codec.register('/cosmos.gov.v1.MsgVoteWeighted', cosmos.gov.v1.MsgVoteWeighted);
+codec.register('/cosmos.gov.v1.MsgVote', cosmos.gov.v1.MsgVote);
 codec.register('/cosmos.gov.v1beta1.TextProposal', cosmos.gov.v1beta1.TextProposal);

--- a/src/types/codec/codec.spec.ts
+++ b/src/types/codec/codec.spec.ts
@@ -188,24 +188,39 @@ describe('codec', () => {
 
   it('protoJSONToInstanceTxMsg', async () => {
     expect.hasAssertions();
-
     const sdk = new cosmosclient.CosmosSDK('https://ununifi-alpha-test-v2.cauchye.net:1318', 'ununifi-alpha-test-v2');
 
-    const hashSend = 'AF78448BFBF4725FA9EF8382B52743210B6EBC3B02BE26C2BCB288202F0DE73B'; //msgSend 100uguu
-    const txResponce = await cosmosclient.rest.tx.getTx(sdk, hashSend).then((res) => res.data);
-    const messase = txResponce.tx?.body?.messages?.[0];
-    const cast = cosmosclient.codec.castProtoJSONOfProtoAny(messase);
-    const instance = cosmosclient.codec.protoJSONToInstance(cast);
-    expect((instance as any).constructor.name).toBe('MsgSend');
-    console.log('cast-msgSend', cast);
-    console.log('instanceMsgSend', instance);
+    const hashSend = "AF78448BFBF4725FA9EF8382B52743210B6EBC3B02BE26C2BCB288202F0DE73B" //msgSend 100uguu
+    const txResponce = await cosmosclient.rest.tx.getTx(sdk, hashSend).then((res) => res.data)
+    const messase = txResponce.tx?.body?.messages?.[0]
+    const cast = cosmosclient.codec.castProtoJSONOfProtoAny(messase)
+    const instance = cosmosclient.codec.protoJSONToInstance(cast)
+    expect((instance as any).constructor.name).toBe("MsgSend");
+    console.log("cast-msgSend", cast)
+    console.log("instanceMsgSend", instance)
 
-    const hashSubmit = '8B21739E3568727D0C30E469910359643E2B85E88B0B223E644566692721F5D8'; //msgSubmitProposal
-    const txResponceS = await cosmosclient.rest.tx.getTx(sdk, hashSubmit).then((res) => res.data);
-    const instanceProposal = cosmosclient.codec.protoJSONToInstance(
-      cosmosclient.codec.castProtoJSONOfProtoAny(txResponceS.tx?.body?.messages?.[0]),
-    );
-    expect((instanceProposal as any).constructor.name).toBe('MsgSubmitProposal');
-    console.log('insetanceProposal', instanceProposal);
+    const hashSubmit = "8B21739E3568727D0C30E469910359643E2B85E88B0B223E644566692721F5D8" //msgSubmitProposal
+    const txResponceS = await cosmosclient.rest.tx.getTx(sdk, hashSubmit).then((res) => res.data)
+    const instanceProposal = cosmosclient.codec.protoJSONToInstance(cosmosclient.codec.castProtoJSONOfProtoAny(txResponceS.tx?.body?.messages?.[0]))
+    expect((instanceProposal as any).constructor.name).toBe("MsgSubmitProposal");
+    console.log("insetanceProposal", instanceProposal)
+
+    const hashDeposit = "41DDF3BB9F1275163CEA9B168925E9410E1686A34ECEEDC58EBCEF81219423CD" //msgDeposit
+    const txResponceDeposit = await cosmosclient.rest.tx.getTx(sdk, hashDeposit).then((res) => res.data)
+    const instanceDeposit = cosmosclient.codec.protoJSONToInstance(cosmosclient.codec.castProtoJSONOfProtoAny(txResponceDeposit.tx?.body?.messages?.[0]))
+    expect((instanceDeposit as any).constructor.name).toBe("MsgDeposit");
+    console.log("instanceDeposit", instanceDeposit)
+
+    const hashVoteWeighted = "66CB9D610E6C65892FF9720534E1AB3D29068B4FF0EAA69554389BC45995205A" //msgVoteWeighted
+    const txResponceVoteWeighted = await cosmosclient.rest.tx.getTx(sdk, hashVoteWeighted).then((res) => res.data)
+    const instanceVoteWeighted = cosmosclient.codec.protoJSONToInstance(cosmosclient.codec.castProtoJSONOfProtoAny(txResponceVoteWeighted.tx?.body?.messages?.[0]))
+    expect((instanceVoteWeighted as any).constructor.name).toBe("MsgVoteWeighted");
+    console.log("instanceVoteWeighted", instanceVoteWeighted)
+
+    const hashVote = "0363D6FA41F145B375E14966E6AED59AC4016BBED8EB7EFA1CEB37149BC9D553" //msgVote
+    const txResponceVote = await cosmosclient.rest.tx.getTx(sdk, hashVote).then((res) => res.data)
+    const instanceVote = cosmosclient.codec.protoJSONToInstance(cosmosclient.codec.castProtoJSONOfProtoAny(txResponceVote.tx?.body?.messages?.[0]))
+    expect((instanceVote as any).constructor.name).toBe("MsgVote");
+    console.log("instanceVote", instanceVote)
   });
 });


### PR DESCRIPTION
@KimuraYu45z cc: @YasunoriMATSUOKA 

Some type of tx could not parse. `(MsgVoteWeighted,MsgVote,MsgDeposit)`
because, these @type changed from v1bata1 to v1 in v0.46.0
So, I fixed it.

Plese review 🙏 