### PR TITLE
feat: expose global `Axios` instance

### DIFF
--- a/src/rest/config.ts
+++ b/src/rest/config.ts
@@ -1,3 +1,4 @@
 import Axios from 'axios';
 
-export const axios = Axios.defaults;
+export const globalAxios = Axios;
+export const axiosDefaults = Axios.defaults;


### PR DESCRIPTION
To use  [`Axios`' interceptors](https://axios-http.com/docs/interceptors), a global instance of `Axios` needs to be accessible.

**Why**

In some cases `Axios` requests need to be tweaked, e.g. for adding custom headers (see #105). Exposing `Axios.defaults` is a good step, but not enough. Global `Axios` instance is needed to use `interceptors` etc.

**Example**

Following code extends `Axios` instance of `@cosmos-client/core` to add a custom header: https://github.com/thorchain/asgardex-electron/blob/develop/src/shared/api/ninerealms.ts Currently it uses a custom fork of `@cosmos-client/core` to expose `globalAxios`. 

Fixes  #105